### PR TITLE
Add optional retry + retry delay for intermittent connections (possibly help with #9)

### DIFF
--- a/waveplus_bridge.py
+++ b/waveplus_bridge.py
@@ -822,9 +822,10 @@ if __name__ == "__main__":
                         # leave retry loop on success
                         break
                     except Exception as err:
-                        lprint("Failed to communicate with device",
-                                wp_device.sn, "/", wp_device.name, ":", err,
-                                file=logf)
+                        lprint("Failed to communicate with device (attempt",
+                            attempt, "of", config.retries + 1, ") ",
+                            wp_device.sn, "/", wp_device.name, ":", err,
+                            file=logf)
                         if not attempt > config.retries:
                             lprint("Retrying in", config.retry_delay, "seconds",
                                     file=logf)

--- a/waveplus_bridge.py
+++ b/waveplus_bridge.py
@@ -87,7 +87,8 @@ class ReadConfiguration:
         for key, value in {
                 "period": 120,
                 "data_retention": 31*24*3600, # 31 days
-                "retries": 3
+                "retries": 3,
+                "retry_delay": 1
         }.items():
             if config[key] is None:
                 config[key] = value
@@ -824,6 +825,10 @@ if __name__ == "__main__":
                         lprint("Failed to communicate with device",
                                 wp_device.sn, "/", wp_device.name, ":", err,
                                 file=logf)
+                        if not attempt > config.retries:
+                            lprint("Retrying in", config.retry_delay, "seconds",
+                                    file=logf)
+                            time.sleep(config.retry_delay)
 
             # Store data in log database
             if ldb is not None:

--- a/waveplus_bridge.py
+++ b/waveplus_bridge.py
@@ -86,7 +86,8 @@ class ReadConfiguration:
         # Apply some default configuration
         for key, value in {
                 "period": 120,
-                "data_retention": 31*24*3600 # 31 days
+                "data_retention": 31*24*3600, # 31 days
+                "retries": 3
         }.items():
             if config[key] is None:
                 config[key] = value
@@ -801,23 +802,28 @@ if __name__ == "__main__":
         
         try:
             for wp_device in wp_devices:
-                try:
-                    # Read the senor values
-                    wp_device.connect()
-                    sensors = wp_device.read()
-                    sdata = sensors.get()
-                    wp_device.disconnect()
-                
-                    # Store the sensor values
-                    sensor_data_no_ts[wp_device.name] = sdata.copy()
-                    sdata["update_time"] = int(time.time())
-                    sensor_data_ts[wp_device.name] = sdata
-                    all_sensor_data_ts[wp_device.name] = sdata
+                attempt = 0
+                while attempt <= config.retries:
+                    attempt += 1
+                    try:
+                        # Read the senor values
+                        wp_device.connect()
+                        sensors = wp_device.read()
+                        sdata = sensors.get()
+                        wp_device.disconnect()
+                    
+                        # Store the sensor values
+                        sensor_data_no_ts[wp_device.name] = sdata.copy()
+                        sdata["update_time"] = int(time.time())
+                        sensor_data_ts[wp_device.name] = sdata
+                        all_sensor_data_ts[wp_device.name] = sdata
 
-                except Exception as err:
-                    lprint("Failed to communicate with device",
-                            wp_device.sn, "/", wp_device.name, ":", err,
-                            file=logf)
+                        # leave retry loop on success
+                        break
+                    except Exception as err:
+                        lprint("Failed to communicate with device",
+                                wp_device.sn, "/", wp_device.name, ":", err,
+                                file=logf)
 
             # Store data in log database
             if ldb is not None:

--- a/waveplus_bridge.yaml
+++ b/waveplus_bridge.yaml
@@ -9,6 +9,8 @@ period: 120
 
 # retries: number of extra attempts to read from the device
 retries: 3
+# amount of time in seconds to wait before attempting reconnection
+retry_delay: 1
 
 # SN: List of 10-digit serial number of one or multiple Wave Plus devices (see 
 # under the magnetic backplate. Each number can be combined with a device 

--- a/waveplus_bridge.yaml
+++ b/waveplus_bridge.yaml
@@ -7,6 +7,9 @@
 # Update period: Time in seconds between reading the sensor values
 period: 120
 
+# retries: number of extra attempts to read from the device
+retries: 3
+
 # SN: List of 10-digit serial number of one or multiple Wave Plus devices (see 
 # under the magnetic backplate. Each number can be combined with a device 
 # nickname, separated by a column from the serial number 


### PR DESCRIPTION
My devices are quite far from the raspberry pi, and there's not a lot I can do about it, sometimes the connection works and sometimes it doesn't.

This just adds a retry which seems to work for me, and hopefully others as well as may be the case in #9 , if there's an underlying issue besides the distance from the pi to the device, then this probably won't help.

![image](https://user-images.githubusercontent.com/75656/173898420-d6f2f91b-ebd0-4104-9efd-6cee509d4470.png)
