### PR TITLE
update battery min max value to better recreate app expierience

### DIFF
--- a/libs/waveplus.py
+++ b/libs/waveplus.py
@@ -133,8 +133,8 @@ class _WavePlusControl():
     _FORMAT = '<BBL12B6H'
     _KEYS = ("illuminance", "battery")  # Not implemented: measurement_periods
     _CMD = struct.pack('<B', 0x6d)
-    _VBAT_MAX = 3.2
-    _VBAT_MIN = 2.2
+    _VBAT_MAX = 2.4
+    _VBAT_MIN = 2.1
     _CACHE_TTL = 3600
     _CACHE_MAX_READS = 100
 


### PR DESCRIPTION
Hi, so i've wondered for a couple of days why my waveplus has "0%" battery but is still reporting its other values accurately.

So i've checked with the offical app and to my surprise the battery value there was 3% - and the other waveplus devices all had 100%, while my mqtt values were in the 20s and 30s.

So I've dug around in your code and found that you've defined rather high values for bat_min and bat_max.

I've changed them to 2.1 and 2.4 respectivly - tell me what you think.